### PR TITLE
Fix camera loading bug and add exit confirmation dialog

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -75,10 +75,25 @@ electron_1.app.whenReady().then(async () => {
     const camWindow = createCameraWindow();
     camWindow.setAlwaysOnTop(true, "floating", 1);
     electron_1.ipcMain.on("shared-window-channel", (event, arg) => {
+        // Handle exit app request
+        if (arg.type === "exit-app") {
+            electron_1.app.quit();
+            event.returnValue = true;
+            return;
+        }
+        // Forward request-webcams to camera window
+        if (arg.type === "request-webcams") {
+            camWindow.webContents.send("shared-window-channel", arg);
+            event.returnValue = true;
+            return;
+        }
+        // Forward all messages to camera window
         camWindow.webContents.send("shared-window-channel", arg);
+        // Forward set-webcams to main window
         if (arg.type === "set-webcams") {
             mainWindow.webContents.send("shared-window-channel", arg);
         }
+        // Handle camera resolution changes
         if (arg.type === "set-camera-resolution" && arg.payload) {
             let { width, height } = arg.payload;
             if (width && height) {

--- a/public/main.ts
+++ b/public/main.ts
@@ -88,12 +88,29 @@ app.whenReady().then(async () => {
   camWindow.setAlwaysOnTop(true, "floating", 1);
 
   ipcMain.on("shared-window-channel", (event, arg: WindowMessage) => {
+    // Handle exit app request
+    if (arg.type === "exit-app") {
+      app.quit();
+      event.returnValue = true;
+      return;
+    }
+
+    // Forward request-webcams to camera window
+    if (arg.type === "request-webcams") {
+      camWindow.webContents.send("shared-window-channel", arg);
+      event.returnValue = true;
+      return;
+    }
+
+    // Forward all messages to camera window
     camWindow.webContents.send("shared-window-channel", arg);
 
+    // Forward set-webcams to main window
     if (arg.type === "set-webcams") {
       mainWindow.webContents.send("shared-window-channel", arg);
     }
 
+    // Handle camera resolution changes
     if (arg.type === "set-camera-resolution" && arg.payload) {
       let { width, height } = arg.payload;
       if (width && height) {

--- a/public/render.js
+++ b/public/render.js
@@ -65,6 +65,15 @@ function renderCamera(constraints) {
     });
 }
 /// <reference path="types.d.ts" />
+function sendWebcamList() {
+    navigator.mediaDevices.enumerateDevices().then((devices) => {
+        const cams = devices.filter((device) => device.kind === "videoinput");
+        window.electronAPI.sendSync("shared-window-channel", {
+            type: "set-webcams",
+            payload: JSON.stringify(cams),
+        });
+    });
+}
 window.addEventListener("DOMContentLoaded", () => {
     navigator.mediaDevices.enumerateDevices().then((devices) => {
         const cams = devices.filter((device) => device.kind === "videoinput");
@@ -85,6 +94,11 @@ window.addEventListener("DOMContentLoaded", () => {
         }
     });
     window.electronAPI.onMessageReceived("shared-window-channel", (_, message) => {
+        // Handle request for webcam list
+        if (message.type === "request-webcams") {
+            sendWebcamList();
+            return;
+        }
         const handler = eventHandlers[message.type];
         if (handler) {
             handler(message.payload);

--- a/public/render.ts
+++ b/public/render.ts
@@ -87,6 +87,16 @@ function renderCamera(constraints: MediaStreamConstraints): void {
 
 /// <reference path="types.d.ts" />
 
+function sendWebcamList(): void {
+  navigator.mediaDevices.enumerateDevices().then((devices) => {
+    const cams = devices.filter((device) => device.kind === "videoinput");
+    window.electronAPI.sendSync("shared-window-channel", {
+      type: "set-webcams",
+      payload: JSON.stringify(cams),
+    });
+  });
+}
+
 window.addEventListener("DOMContentLoaded", () => {
   navigator.mediaDevices.enumerateDevices().then((devices) => {
     const cams = devices.filter((device) => device.kind === "videoinput");
@@ -111,6 +121,12 @@ window.addEventListener("DOMContentLoaded", () => {
   window.electronAPI.onMessageReceived(
     "shared-window-channel",
     (_, message) => {
+      // Handle request for webcam list
+      if (message.type === "request-webcams") {
+        sendWebcamList();
+        return;
+      }
+
       const handler = eventHandlers[message.type];
       if (handler) {
         handler(message.payload);

--- a/src/App.css
+++ b/src/App.css
@@ -278,3 +278,127 @@ body {
   background-color: #4e54c8;
   color: #fff;
 }
+
+/* Confirmation Dialog */
+.confirm-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100000;
+  animation: fadeIn 0.2s ease;
+  -webkit-app-region: no-drag;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.confirm-dialog {
+  background: linear-gradient(145deg, rgb(55, 65, 81), rgb(45, 55, 72));
+  border-radius: 24px;
+  padding: 40px;
+  width: 420px;
+  max-width: 90%;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.6);
+  animation: slideUp 0.3s ease;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.confirm-dialog-icon {
+  color: rgba(251, 191, 36, 0.9);
+  margin-bottom: 24px;
+  display: flex;
+  justify-content: center;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1.05);
+  }
+}
+
+.confirm-dialog-title {
+  color: white;
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  letter-spacing: -0.5px;
+}
+
+.confirm-dialog-message {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 15px;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+
+.confirm-dialog-buttons {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.confirm-dialog-button {
+  padding: 12px 32px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: none;
+  outline: none;
+  min-width: 120px;
+}
+
+.confirm-dialog-button.cancel {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.confirm-dialog-button.cancel:hover {
+  background: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.confirm-dialog-button.confirm {
+  background: linear-gradient(135deg, rgb(239, 68, 68), rgb(220, 38, 38));
+  color: white;
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.4);
+}
+
+.confirm-dialog-button.confirm:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(239, 68, 68, 0.6);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import "./App.css";
 import Sidebar from "./components/Sidebar";
+import { CameraProvider } from "./contexts/CameraContext";
 
 function App(): JSX.Element {
   return (
-    <div className="app-container">
-      <Sidebar />
-    </div>
+    <CameraProvider>
+      <div className="app-container">
+        <Sidebar />
+      </div>
+    </CameraProvider>
   );
 }
 

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,33 @@
+import { AlertCircle } from "lucide-react";
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({ isOpen, onConfirm, onCancel }: ConfirmDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="confirm-dialog-overlay">
+      <div className="confirm-dialog">
+        <div className="confirm-dialog-icon">
+          <AlertCircle size={48} strokeWidth={1.5} />
+        </div>
+        <h2 className="confirm-dialog-title">Exit Floatcam?</h2>
+        <p className="confirm-dialog-message">
+          Are you sure you want to close Floatcam? All windows will be closed.
+        </p>
+        <div className="confirm-dialog-buttons">
+          <button className="confirm-dialog-button cancel" onClick={onCancel}>
+            Cancel
+          </button>
+          <button className="confirm-dialog-button confirm" onClick={onConfirm}>
+            Exit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,12 +15,16 @@ import FlipPopover from "./popovers/FlipPopover";
 import ShapePopover from "./popovers/ShapePopover";
 import FilterPopover from "./popovers/FilterPopover";
 import BorderPopover from "./popovers/BorderPopover";
+import ConfirmDialog from "./ConfirmDialog";
+
+const { electronAPI } = window;
 
 type PopoverType = "camera" | "size" | "flip" | "shape" | "filter" | "border" | null;
 
 export default function Sidebar() {
   const [activePopover, setActivePopover] = useState<PopoverType>(null);
   const [popoverPosition, setPopoverPosition] = useState<number>(0);
+  const [showExitDialog, setShowExitDialog] = useState<boolean>(false);
 
   const togglePopover = (popover: PopoverType, event: React.MouseEvent<HTMLButtonElement>) => {
     if (activePopover === popover) {
@@ -65,7 +69,19 @@ export default function Sidebar() {
   };
 
   const handleExit = () => {
-    window.close();
+    setShowExitDialog(true);
+  };
+
+  const confirmExit = () => {
+    // Send message to main process to close all windows
+    electronAPI.sendSync("shared-window-channel", {
+      type: "exit-app",
+      payload: "",
+    });
+  };
+
+  const cancelExit = () => {
+    setShowExitDialog(false);
   };
 
   return (
@@ -197,6 +213,13 @@ export default function Sidebar() {
           <BorderPopover />
         </div>
       )}
+
+      {/* Exit confirmation dialog */}
+      <ConfirmDialog
+        isOpen={showExitDialog}
+        onConfirm={confirmExit}
+        onCancel={cancelExit}
+      />
     </div>
   );
 }

--- a/src/components/popovers/CameraPopover.tsx
+++ b/src/components/popovers/CameraPopover.tsx
@@ -1,31 +1,9 @@
-import { useState, useEffect } from "react";
-import { WebcamDevice } from "../../types";
+import { useCameraContext } from "../../contexts/CameraContext";
 
 const { electronAPI } = window;
 
-interface WindowMessage {
-  type: string;
-  payload: string;
-}
-
 export default function CameraPopover() {
-  const [webcams, setWebcams] = useState<WebcamDevice[]>([
-    { deviceId: "loading", label: "Loading..." },
-  ]);
-  const [selectedCamera, setSelectedCamera] = useState<string>("");
-
-  useEffect(() => {
-    electronAPI.onMessageReceived("shared-window-channel", (_, message) => {
-      const msg = message as WindowMessage;
-      if (msg.type === "set-webcams") {
-        const devices = JSON.parse(msg.payload) as WebcamDevice[];
-        setWebcams(devices);
-        if (devices.length > 0) {
-          setSelectedCamera(devices[0].deviceId);
-        }
-      }
-    });
-  }, []);
+  const { webcams, selectedCamera, setSelectedCamera } = useCameraContext();
 
   const handleChange = (deviceId: string): void => {
     setSelectedCamera(deviceId);

--- a/src/contexts/CameraContext.tsx
+++ b/src/contexts/CameraContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import { WebcamDevice } from "../types";
+
+const { electronAPI } = window;
+
+interface WindowMessage {
+  type: string;
+  payload: string;
+}
+
+interface CameraContextType {
+  webcams: WebcamDevice[];
+  selectedCamera: string;
+  setSelectedCamera: (deviceId: string) => void;
+}
+
+const CameraContext = createContext<CameraContextType | undefined>(undefined);
+
+export function CameraProvider({ children }: { children: ReactNode }) {
+  const [webcams, setWebcams] = useState<WebcamDevice[]>([
+    { deviceId: "loading", label: "Loading..." },
+  ]);
+  const [selectedCamera, setSelectedCamera] = useState<string>("");
+
+  useEffect(() => {
+    // Set up listener for webcam updates
+    electronAPI.onMessageReceived("shared-window-channel", (_, message) => {
+      const msg = message as WindowMessage;
+      if (msg.type === "set-webcams") {
+        const devices = JSON.parse(msg.payload) as WebcamDevice[];
+        setWebcams(devices);
+        if (devices.length > 0) {
+          setSelectedCamera((current) => current || devices[0].deviceId);
+        }
+      }
+    });
+
+    // Request the webcam list when component mounts
+    electronAPI.sendSync("shared-window-channel", {
+      type: "request-webcams",
+      payload: "",
+    });
+  }, []); // Only run once on mount
+
+  return (
+    <CameraContext.Provider value={{ webcams, selectedCamera, setSelectedCamera }}>
+      {children}
+    </CameraContext.Provider>
+  );
+}
+
+export function useCameraContext() {
+  const context = useContext(CameraContext);
+  if (context === undefined) {
+    throw new Error("useCameraContext must be used within a CameraProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- Fixed race condition preventing camera list from loading
- Added beautiful exit confirmation dialog with animations
- Implemented React Context for camera state management

## Bug Fixes

### Camera Loading Issue
**Problem:** The camera dropdown was stuck on "Loading..." and never showed actual cameras.

**Root Cause:** Race condition where the camera window sent the webcam list before the React app mounted and set up the IPC listener.

**Solution:**
- Created `CameraContext` to manage webcams state in an always-mounted component
- Implemented `request-webcams` IPC message for on-demand camera list refresh
- Camera list is now requested when the React app mounts, ensuring the listener is ready
- Refactored `CameraPopover` to consume shared context instead of maintaining local state

## New Features

### Exit Confirmation Dialog
- Beautiful modal dialog appears when clicking the X button
- Features:
  - Animated warning icon with pulse effect
  - Gradient background with backdrop blur
  - Smooth slide-up animation
  - Two buttons: Cancel (gray) and Exit (red gradient)
- Main process handles `exit-app` message to gracefully quit all windows

## Technical Changes

**Frontend:**
- `src/contexts/CameraContext.tsx` - New context provider for camera state
- `src/components/ConfirmDialog.tsx` - New confirmation dialog component
- `src/components/Sidebar.tsx` - Added exit dialog state and handlers
- `src/components/popovers/CameraPopover.tsx` - Refactored to use context
- `src/App.tsx` - Wrapped with CameraProvider
- `src/App.css` - Added dialog styles with animations

**Backend:**
- `public/main.ts` - Added handlers for `exit-app` and `request-webcams` messages
- `public/render.ts` - Added `sendWebcamList()` function and request handler

## Testing
- [x] Camera dropdown now loads camera list correctly
- [x] Exit button shows confirmation dialog
- [x] Cancel button closes dialog without exiting
- [x] Exit button closes all windows (main + camera)
- [x] All existing functionality works as expected